### PR TITLE
Add REST endpoints for communityPost, location, and account

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'rest_framework',
     'redcycle.apps.RedcycleConfig'
 ]
 
@@ -119,3 +120,9 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.1/howto/static-files/
 
 STATIC_URL = '/redcycle-api/static/'
+
+REST_FRAMEWORK = {
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly'
+    ]
+}

--- a/app/urls.py
+++ b/app/urls.py
@@ -1,18 +1,3 @@
-"""app URL Configuration
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/3.1/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  path('', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.urls import include, path
-    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
-"""
 from django.contrib import admin
 from django.urls import path, include
 

--- a/redcycle/admin.py
+++ b/redcycle/admin.py
@@ -1,5 +1,7 @@
 from django.contrib import admin
-from .models.models import Account, Location, CommunityPost
+from .models.Account import *
+from .models.CommunityPost import *
+from .models.Location import *
 
 admin.site.register(Account)
 admin.site.register(Location)

--- a/redcycle/models/Account.py
+++ b/redcycle/models/Account.py
@@ -1,8 +1,8 @@
 from django.db import models
-import uuid
+from uuid import uuid4
 
 class Account(models.Model):
-    id = models.UUIDField(primary_key=True, editable=False, unique=True, default=uuid.uuid4)
+    id = models.UUIDField(primary_key=True, editable=False, unique=True, default=uuid4)
     firstName = models.CharField(max_length=100)
     lastName = models.CharField(max_length=100)
     email = models.CharField(max_length=100)

--- a/redcycle/models/CommunityPost.py
+++ b/redcycle/models/CommunityPost.py
@@ -1,11 +1,11 @@
 from django.db import models
-import uuid
-from .Account import Account
-from .Location import Location
-from ..enums.CategoryEnum import CategoryEnum
+from uuid import uuid4
+from .Account import *
+from .Location import *
+from ..enums.CategoryEnum import *
 
 class CommunityPost(models.Model):
-    id = models.UUIDField(primary_key=True, editable=False, unique=True, default=uuid.uuid4)
+    id = models.UUIDField(primary_key=True, editable=False, unique=True, default=uuid4)
     title = models.CharField(max_length=200)
     description = models.CharField(max_length=1000)
     creationDate = models.DateTimeField()

--- a/redcycle/models/Location.py
+++ b/redcycle/models/Location.py
@@ -1,10 +1,10 @@
 from django.db import models
-import uuid
-from .Account import Account
-from ..enums.StateEnum import StateEnum
+from uuid import uuid4
+from .Account import *
+from ..enums.StateEnum import *
 
 class Location(models.Model):
-    id = models.UUIDField(primary_key=True, editable=False, unique=True, default=uuid.uuid4)
+    id = models.UUIDField(primary_key=True, editable=False, unique=True, default=uuid4)
     street = models.CharField(max_length=100, null=True)
     city = models.CharField(max_length=100)
     postalCode = models.CharField(max_length=6)

--- a/redcycle/models/models.py
+++ b/redcycle/models/models.py
@@ -1,3 +1,0 @@
-from .Account import Account
-from .Location import Location
-from .CommunityPost import CommunityPost

--- a/redcycle/serializers/AccountSerializer.py
+++ b/redcycle/serializers/AccountSerializer.py
@@ -1,0 +1,7 @@
+from rest_framework import serializers
+from ..models.Account import *
+
+class AccountSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Account
+        fields = ['id', 'firstName', 'lastName', 'email', 'active']

--- a/redcycle/serializers/CommunityPostSerializer.py
+++ b/redcycle/serializers/CommunityPostSerializer.py
@@ -1,0 +1,7 @@
+from rest_framework import serializers
+from ..models.CommunityPost import *
+
+class CommunityPostSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = CommunityPost
+        fields = ['id', 'title', 'description', 'creationDate', 'available', 'category', 'authorId', 'locationId']

--- a/redcycle/serializers/LocationSerializer.py
+++ b/redcycle/serializers/LocationSerializer.py
@@ -1,0 +1,7 @@
+from rest_framework import serializers
+from ..models.Location import *
+
+class LocationSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Location
+        fields = ['id', 'street', 'city', 'postalCode', 'state', 'description', 'authorId']

--- a/redcycle/urls.py
+++ b/redcycle/urls.py
@@ -1,7 +1,15 @@
-from django.urls import path
+from django.urls import include, path
+from rest_framework import routers
+from .views.AccountViewSet import *
+from .views.LocationViewSet import *
+from .views.CommunityPostViewSet import *
 
-from . import views
+router = routers.DefaultRouter()
+router.register(r'/accounts', AccountViewSet)
+router.register(r'/locations', LocationViewSet)
+router.register(r'/communityPosts', CommunityPostViewSet)
 
 urlpatterns = [
-    path('', views.index, name='index'),
+    path('', include(router.urls)),
+    path('api-auth/', include('rest_framework.urls', namespace='rest_framework'))
 ]

--- a/redcycle/views.py
+++ b/redcycle/views.py
@@ -1,4 +1,0 @@
-from django.http import HttpResponse
-
-def index(request):
-    return HttpResponse("Hello, world. You're at the redcycle index.")

--- a/redcycle/views/AccountViewSet.py
+++ b/redcycle/views/AccountViewSet.py
@@ -1,0 +1,7 @@
+from rest_framework import viewsets
+from ..serializers.AccountSerializer import *
+from ..models.Account import *
+
+class AccountViewSet(viewsets.ModelViewSet):
+    queryset = Account.objects.all().order_by('firstName')
+    serializer_class = AccountSerializer

--- a/redcycle/views/CommunityPostViewSet.py
+++ b/redcycle/views/CommunityPostViewSet.py
@@ -1,0 +1,7 @@
+from rest_framework import viewsets
+from ..serializers.CommunityPostSerializer import *
+from ..serializers.CommunityPostSerializer import *
+
+class CommunityPostViewSet(viewsets.ModelViewSet):
+    queryset = CommunityPost.objects.all().order_by('creationDate')
+    serializer_class = CommunityPostSerializer

--- a/redcycle/views/LocationViewSet.py
+++ b/redcycle/views/LocationViewSet.py
@@ -1,0 +1,7 @@
+from rest_framework import viewsets
+from ..serializers.LocationSerializer import *
+from ..models.Location import *
+
+class LocationViewSet(viewsets.ModelViewSet):
+    queryset = Location.objects.all().order_by('state')
+    serializer_class = LocationSerializer

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
-Django>=3.0,<4.0
-psycopg2-binary>=2.8
+Django==3.1
+psycopg2-binary==2.8
+djangorestframework
+markdown
+django-filter


### PR DESCRIPTION
Uses Django REST framework to add the following endpoints:
  * `/redcycle-api/communityPosts`
  * `/redcycle-api/locations`
  * `/redcycle-api/accounts`

You can try these endpoints by running the project and going to one of the paths, like `http://localhost:8000/redcycle-api/communityPosts`

I also made some tweaks to the models and organization. 